### PR TITLE
Changed functools to functools32 for py2.7 compatibility

### DIFF
--- a/idb/idapython.py
+++ b/idb/idapython.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 import re
 import logging
 import weakref
-import functools
+import functools32
 import collections
 
 import six
@@ -18,13 +18,13 @@ logger = logging.getLogger(__name__)
 # via: https://stackoverflow.com/a/33672499/87207
 def memoized_method(*lru_args, **lru_kwargs):
     def decorator(func):
-        @functools.wraps(func)
+        @functools32.wraps(func)
         def wrapped_func(self, *args, **kwargs):
             # We're storing the wrapped method inside the instance. If we had
             # a strong reference to self the instance would never die.
             self_weak = weakref.ref(self)
-            @functools.wraps(func)
-            @functools.lru_cache(*lru_args, **lru_kwargs)
+            @functools32.wraps(func)
+            @functools32.lru_cache(*lru_args, **lru_kwargs)
             def cached_method(*args, **kwargs):
                 return func(self_weak(), *args, **kwargs)
             setattr(self, func.__name__, cached_method)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'hexdump',
         'capstone',
         'vivisect-vstruct-wb>=1.0.3',
+        'functools32'
     ],
     packages=find_packages(exclude=['*.tests', '*.tests.*']),
     entry_points={


### PR DESCRIPTION
py2.7 doesn't have functools.lru_cache -- if I were smarter I would be able to use functools on 3.x and a replacement for py2.7.