### PR TITLE
Bumping Python version in Travis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+name: Python IDB
+on: [push, pull_request]
+
+jobs:
+    build:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest, macos-latest, windows-latest]
+                python-version: ['2.7', '3.6', '3.7', '3.8']
+
+        name: Python ${{ matrix.python-version }} at ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup python
+              uses: actions/setup-python@v2
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  architecture: x64
+            - name: Install dependencies
+              run: |
+                pip install --upgrade pip
+                pip install -I PyPI capstone flake8
+                pip install --upgrade pytest-cov pytest
+                pip install -e .
+            - name: QA checks
+              run: |
+                # stop the build if there are Python syntax errors or undefined names
+                flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+                # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+                flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+            - name: Run tests
+              run: |
+                find . -name \*.py -exec pycodestyle --ignore=E501 {} \;
+                py.test ./tests/ -v --cov=idb
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
           python: 2.7
 
         - os: linux
-          python: 3.5
+          python: 3.6
 
 install:
     - pip install --upgrade pip

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -78,6 +78,13 @@ COMMON_FIXTURES = {
     (700, 64): load_idb(os.path.join(CD, 'data', 'v7.0b', 'x64', 'kernel32.i64')),
 }
 
+@pytest.fixture
+def runslow(request):
+    return request.config.getoption("--runslow")
+
+@pytest.fixture
+def rundebug(request):
+    return request.config.getoption("--rundebug")
 
 def kern32_test(specs=None):
     '''

--- a/tests/test_idaapi.py
+++ b/tests/test_idaapi.py
@@ -7,7 +7,7 @@ from fixtures import *
 
 
 slow = pytest.mark.skipif(
-    not pytest.config.getoption("--runslow"),
+    not runslow,
     reason="need --runslow option to run"
 )
 

--- a/tests/test_idb.py
+++ b/tests/test_idb.py
@@ -8,7 +8,7 @@ import idb.fileformat
 
 
 slow = pytest.mark.skipif(
-    not pytest.config.getoption("--runslow"),
+    not runslow,
     reason="need --runslow option to run"
 )
 

--- a/tests/test_netnode.py
+++ b/tests/test_netnode.py
@@ -6,7 +6,7 @@ from fixtures import *
 
 
 debug = pytest.mark.skipif(
-    not pytest.config.getoption("--rundebug"),
+    not rundebug,
     reason="need --rundebug option to run"
 )
 


### PR DESCRIPTION
Python 3.5 left only in a few non-mainstream and slowly paced distributions: https://repology.org/project/python3/versions

[![Packaging status](https://repology.org/badge/vertical-allrepos/python.svg)](https://repology.org/project/python/versions)