### PR TITLE
Fix the APIs idautils.CodeRefsTo() and idautils.CodeRefsFrom()

### DIFF
--- a/idb/idapython.py
+++ b/idb/idapython.py
@@ -2487,7 +2487,7 @@ class idautils:
         # get all the code xrefs to this instruction.
         # a code xref is like a fallthrough or jump, not like a call.
         for xref in idb.analysis.get_crefs_to(
-            self.idb, ea, types=[idaapi.fl_JN, idaapi.fl_JF, idaapi.fl_F]
+            self.idb, ea, types=[idaapi.fl_JN, idaapi.fl_JF, idaapi.fl_F, idaapi.fl_CN, idaapi.fl_CF]
         ):
             yield xref.frm
 

--- a/idb/idapython.py
+++ b/idb/idapython.py
@@ -2485,7 +2485,7 @@ class idautils:
                 yield ftf.frm
 
         # get all the code xrefs to this instruction.
-        # a code xref is like a fallthrough or jump, not like a call.
+        # a code xref is like a fallthrough, jump or call.
         for xref in idb.analysis.get_crefs_to(
             self.idb, ea, types=[idaapi.fl_JN, idaapi.fl_JF, idaapi.fl_F, idaapi.fl_CN, idaapi.fl_CF]
         ):
@@ -2509,9 +2509,9 @@ class idautils:
                 yield ftf.to
 
         # get all the code xrefs from this instruction.
-        # a code xref is like a fallthrough or jump, not like a call.
+        # a code xref is like a fallthrough, jump or call
         for xref in idb.analysis.get_crefs_from(
-            self.idb, ea, types=[idaapi.fl_JN, idaapi.fl_JF, idaapi.fl_F]
+            self.idb, ea, types=[idaapi.fl_JN, idaapi.fl_JF, idaapi.fl_F, idaapi.fl_CN, idaapi.fl_CF]
         ):
             yield xref.to
 


### PR DESCRIPTION
In the issue #72, we found that the implementation of CodeRefsTo() excludes all call type cross-references, which is inconsistent with the results of CodeRefsTo() in IDA Pro 7.0.
```python
# a code xref is like a fallthrough or jump, not like a call.
for xref in idb.analysis.get_crefs_to(self.idb, ea,
     types=[idaapi.fl_JN, idaapi.fl_JF, idaapi.fl_F]):
     yield xref.frm
```
According to the comment, the developers excluded the calling flows. However, we found that the CodeRefsTo should include the calling flows according to an example in the idapython project (link). In the code, they use ``CodeRefsTo`` to find all callers of the target function. Thus, we modify the implementation of ``CodeRefsTo`` (also the ``CodeRefsFrom``) to include the call flows.