### PR TITLE
fix decode error

### DIFF
--- a/idb/analysis.py
+++ b/idb/analysis.py
@@ -424,7 +424,7 @@ class Reader(idb.typeinf.TypeString):
         return self.read(size)
 
     def str(self, size, encoding="utf-8"):
-        return self.read(size).decode(encoding)
+        return self.read(size).decode(encoding, errors="ignore")
 
     def u16(self, big=False):
         if big:


### PR DESCRIPTION
In my execution environment, I get the following error. So I fixed the decoding part.

```(venv) D:\test_idb>python test_idb.py
Traceback (most recent call last):
  File "test\test_idb.py", line 3, in <module>
    with idb.from_file('NetBase.dll.i64') as db:
  File "c:\Python310\lib\contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "test\venv\lib\site-packages\idb\__init__.py", line 33, in from_file
    db.vsParse(buf)
  File "test\venv\lib\site-packages\vstruct\__init__.py", line 145, in vsParse
    self._vsFireCallbacks(fname)
  File "test\venv\lib\site-packages\vstruct\__init__.py", line 88, in _vsFireCallbacks
    callback()
  File "test\venv\lib\site-packages\idb\fileformat.py", line 1199, in pcb_header
    s.inf = Root(self).idainfo
  File "test\venv\lib\site-packages\idb\analysis.py", line 365, in __getattr__
    return field.cast(bytes(v), wordsize=self.idb.wordsize)
  File "test\venv\lib\site-packages\idb\analysis.py", line 96, in inner
    return cast(buf, V, wordsize=wordsize)
  File "test\venv\lib\site-packages\idb\analysis.py", line 74, in cast
    v.vsParse(buf)
  File "test\venv\lib\site-packages\idb\analysis.py", line 636, in vsParse
    self.procname = reader.str(16)
  File "test\venv\lib\site-packages\idb\analysis.py", line 427, in str
    return self.read(size).decode(encoding)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x82 in position 8: invalid start byte
```